### PR TITLE
Provide a cleaner implementation of the merge sort algorithm in go.

### DIFF
--- a/sort/merge_sort/go/merge_sort.go
+++ b/sort/merge_sort/go/merge_sort.go
@@ -1,51 +1,40 @@
-package main
+package mergesort
 
-import "fmt"
-
-func main() {
-	arr := []int{5,15,154,1,3,2,4,8,9,5,8,4,5,6,3,2,4,5}
-
-	fmt.Printf("Unsorted: %v\n", arr)
-	fmt.Printf("Sorted: %v\n", Sort(arr))
+// MergeSort uses the merge sort algorithm to sort an integer slice.
+func MergeSort(slice []int) {
+	sortedSlice := mergeSort(slice)
+	for i, val := range sortedSlice {
+		slice[i] = val
+	}
 }
 
-func merge(left []int, right []int) []int {
-	var arr = make([]int, len(left) + len(right))
-	var leftIndex = 0
-	var rightIndex = 0
+func mergeSort(slice []int) []int {
+	if len(slice) <= 1 {
+		return slice
+	}
+	m := len(slice) / 2
+	left := mergeSort(slice[:m])
+	right := mergeSort(slice[m:])
+	return merge(left, right)
+}
 
-	for leftIndex < len(left) && rightIndex < len(right) {
-
-		if left[leftIndex] <= right[rightIndex] {
-			arr[leftIndex+rightIndex] = left[leftIndex]
-			leftIndex++
+func merge(left, right []int) []int {
+	slice := make([]int, len(left)+len(right))
+	i, j := 0, 0
+	for i < len(left) && j < len(right) {
+		if left[i] <= right[j] {
+			slice[i+j] = left[i]
+			i++
 		} else {
-			arr[leftIndex+rightIndex] = right[rightIndex]
-			rightIndex++
+			slice[i+j] = right[j]
+			j++
 		}
-
 	}
-
-	for ; leftIndex < len(left); leftIndex++ {
-		arr[leftIndex+rightIndex] = left[leftIndex]
+	for ; i < len(left); i++ {
+		slice[i+j] = left[i]
 	}
-
-	for ; rightIndex < len(right); rightIndex++ {
-		arr[leftIndex+rightIndex] = right[rightIndex]
+	for ; j < len(right); j++ {
+		slice[i+j] = right[j]
 	}
-
-	return arr
-}
-
-func Sort(items []int) []int {
-	if len(items) < 2 {
-		return items
-	}
-
-	middle := len(items) / 2
-
-	a := Sort(items[:middle])
-	b := Sort(items[middle:])
-
-	return merge(a, b)
+	return slice
 }

--- a/sort/merge_sort/go/merge_sort_test.go
+++ b/sort/merge_sort/go/merge_sort_test.go
@@ -1,0 +1,39 @@
+package mergesort
+
+import (
+	"sort"
+	"testing"
+)
+
+func equal(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestBubbleSort(t *testing.T) {
+	testCases := [][]int{
+		{2, 1, 2, 7, 88, 4, 3, 6},
+		{-2, 1, -2, -40, 10, 11, 48, -44, 0, 21, -121, 5066},
+		{23, 12, 11, -20, 3, 1, -20, 3, 8, 9},
+		{8, 7, 5, 4, 3, 2, 1},
+	}
+	for _, arr1 := range testCases {
+		arr2 := make([]int, len(arr1))
+		copy(arr2, arr1)
+
+		MergeSort(arr1)
+		sort.Ints(arr2)
+
+		if !equal(arr1, arr2) {
+			t.Errorf("MergeSort did not sort correctly.")
+		}
+	}
+
+}


### PR DESCRIPTION
I have modified the golang implementation of the merge sort algorithm.
 - To be consistent with the other sorting algorithm implementation in go (like "Bubble Sort" or "Insertion Sort"), the main sorting function should look like ```func Sort([]int slice)``` this, and sort the passed slice instead of returning a copy of the sorted slice.
 - Use the testing framework that the Go programming language provides, instead of manually testing in the main function.