### PR TITLE
Add Haskell implementation of insertion sort

### DIFF
--- a/sort/insertion_sort/haskell/InsertionSort.hs
+++ b/sort/insertion_sort/haskell/InsertionSort.hs
@@ -1,0 +1,4 @@
+module InsertionSort (insertionSort) where
+import Data.List (insert)
+insertionSort :: Ord a => [a] -> [a]
+insertionSort l = foldr insert [] l

--- a/sort/insertion_sort/haskell/InsertionSortTest.hs
+++ b/sort/insertion_sort/haskell/InsertionSortTest.hs
@@ -1,0 +1,15 @@
+module InsertionSortTest.Main (main) where
+import Data.List (sort)
+
+import InsertionSort (insertionSort)
+
+main :: IO ()
+main = do
+    if test
+    then putStrLn "List sorted correctly"
+    else putStrLn "Error: List did not sort correctly"
+
+test :: Bool
+test = sort list == insertionSort list
+  where
+    list = [12,3,55,1,2,7,4]


### PR DESCRIPTION
This adds a Haskell implementation of the insertion sort. Possibly the shortest sorting algorithm I've ever written. Let me know if you'd like me to add a custom implementation of `insert` rather than using the standard library version, to show how to implement that.