### PR TITLE
Add version of Haskell insertion sort with custom insert function

### DIFF
--- a/sort/insertion_sort/haskell/InsertionSortTest.hs
+++ b/sort/insertion_sort/haskell/InsertionSortTest.hs
@@ -1,15 +1,18 @@
 module InsertionSortTest.Main (main) where
 import Data.List (sort)
 
-import InsertionSort (insertionSort)
+import qualified InsertionSort as StdLibIns
+import qualified InsertionSortWithCustomInsert as CustomIns
 
 main :: IO ()
 main = do
-    if test
+    putStr "Standard library `insert`: "
+    test StdLibIns.insertionSort
+    putStr "Custom `insert`: "
+    test CustomIns.insertionSort
+
+test :: ([Int] -> [Int]) -> IO ()
+test f = if f list == sort list
     then putStrLn "List sorted correctly"
     else putStrLn "Error: List did not sort correctly"
-
-test :: Bool
-test = sort list == insertionSort list
-  where
-    list = [12,3,55,1,2,7,4]
+  where list = [12,3,55,1,2,7,4]

--- a/sort/insertion_sort/haskell/InsertionSortWithCustomInsert.hs
+++ b/sort/insertion_sort/haskell/InsertionSortWithCustomInsert.hs
@@ -1,0 +1,10 @@
+module InsertionSortWithCustomInsert (insertionSort) where
+
+insert :: Ord a => a -> [a] -> [a]
+insert x [] = [x]
+insert x (y:xs)
+    | y < x = y : insert x xs
+    | otherwise = x:y:xs
+
+insertionSort :: Ord a => [a] -> [a]
+insertionSort l = foldr insert [] l


### PR DESCRIPTION
This adds a version of the Haskell insertion sort that uses a custom `insert` function rather than the one in the standard library module `Data.List`, as discussed in PR #41.

The test file now tests both versions