### PR TITLE
Einstein puzzle implementations in Clojure and Prolog

### DIFF
--- a/puzzles/Einstein_Puzzle/clojure/README.md
+++ b/puzzles/Einstein_Puzzle/clojure/README.md
@@ -1,0 +1,7 @@
+Clojure solution to Einstein's puzzle using `core.logic`.
+
+Can be run with [Leiningen](https://leiningen.org/):
+
+```bash
+$ lein run
+```

--- a/puzzles/Einstein_Puzzle/clojure/project.clj
+++ b/puzzles/Einstein_Puzzle/clojure/project.clj
@@ -1,0 +1,7 @@
+(defproject einstein-puzzle "1.0.0"
+  :description "Einstein puzzle solution using core.logic"
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.clojure/core.logic "0.8.11"]
+                 [org.clojure/tools.macro "0.1.2"]]
+  :main solution
+  :source-paths ["."])

--- a/puzzles/Einstein_Puzzle/clojure/solution.clj
+++ b/puzzles/Einstein_Puzzle/clojure/solution.clj
@@ -1,0 +1,72 @@
+(ns solution
+  (:refer-clojure :exclude [==])
+  (:use [clojure.core.logic]
+        [clojure.tools.macro :only [symbol-macrolet]]))
+
+(defn lefto [x y p]
+  (all
+    (matche [p]
+      ([[x y _ _ _]])
+      ([[_ x y _ _]])
+      ([[_ _ x y _]])
+      ([[_ _ _ x y]]))))
+
+
+(defn nexto [x y p]
+  (conde
+    ((lefto x y p))
+    ((lefto y x p))))
+
+
+; "g" is a list of attribute lists for each person, each in form:
+; [Nationality, Color, Pet, Drink, Smoke]
+(defn puzzleo [g]
+  (symbol-macrolet
+    [_ (lvar)]
+    (all
+      ; 0. Structural constraint:
+      ; The number of people should be 5
+      (== [_ _ _ _ _] g)
+
+      ; 1. Constraints, as corresponding to the text
+      ;  (following verbatim in comments):
+
+      ; The Englishman lives in the red house
+      (membero ['englishman 'red _ _ _] g)
+      ; The Swede keeps dogs
+      (membero ['swede _ 'dogs _ _] g)
+      ; The Dane drinks tea
+      (membero ['dane _ _ 'tea _] g)
+      ; The green house is just to the left of the white one
+      (lefto [_ 'green _ _ _] [_ 'white _ _ _] g)
+      ; The owner of the green house drinks coffee
+      (membero [_ 'green _ 'coffee _] g)
+      ; The Pall Mall smoker keeps birds
+      (membero [_ _ 'birds _ 'pallmall] g)
+      ; The owner of the yellow house smokes Dunhills
+      (membero [_ 'yellow _ _ 'dunhill] g)
+      ; The man in the center house drinks milk
+      (== [_ _ [_ _ _ 'milk _] _ _] g)
+      ; The Norwegian lives in the first house
+      (== [['norwegian _ _ _ _] _ _ _ _] g)
+      ; The Blend smoker has a neighbor who keeps cats
+      (nexto [_ _ _ _ 'blend] [_ _ 'cats _ _] g)
+      ; The man who smokes Blue Masters drinks bier
+      (membero [_ _ _ 'bier 'bluemasters] g)
+      ; The man who keeps horses lives next to the Dunhill smoker
+      (nexto [_ _ _ _ 'dunhill] [_ _ 'horses _ _] g)
+      ; The German smokes Prince
+      (membero ['german _ _ _ 'prince] g)
+      ; The Norwegian lives next to the blue house
+      (nexto ['norwegian _ _ _ _] [_ 'blue _ _ _] g)
+      ; The Blend smoker has a neighbor who drinks water
+      (nexto [_ _ _ _ 'blend] [_ _ _ 'water _] g)
+
+      ; 3. Implicit constraints:
+      ; Pad with information about unmentioned atoms
+      (membero [_ _ 'fish _ _] g))))
+
+
+(defn -main [& args]
+  (let [sol (first (run* [g] (puzzleo g)))]
+    (println "Solution:" sol)))

--- a/puzzles/Einstein_Puzzle/prolog/README.md
+++ b/puzzles/Einstein_Puzzle/prolog/README.md
@@ -1,0 +1,7 @@
+Prolog solution to Einstein's puzzle.
+
+Can be run with [SWI Prolog](http://www.swi-prolog.org/):
+
+```bash
+$ prolog -c solution.pro
+```

--- a/puzzles/Einstein_Puzzle/prolog/solution.pro
+++ b/puzzles/Einstein_Puzzle/prolog/solution.pro
@@ -1,0 +1,68 @@
+% The "left of" predicate
+left([fleft |_], [left  |_]).
+left([left  |_], [center|_]).
+left([center|_], [right |_]).
+left([right |_], [fright|_]).
+
+left(A, B, L) :-
+  member(A, L),
+  member(B, L),
+  left(A, B).
+
+% The "next to" predicate
+next(A, B, L) :- left(A, B, L).
+next(A, B, L) :- left(B, A, L).
+
+% "G" is a list of attribute lists for each person, each in form:
+% [Position, Nationality, Color, Pet, Drink, Smoke]
+puzzle(G) :-
+  % 0. Structural constraint:
+  % The number of guests should be 5
+  length(G, 5),
+
+  % 1. Constraints, as corresponding to the text
+  %  (following verbatim in comments):
+  % The Englishman lives in the red house
+  member([_, englishman, red, _, _, _], G),
+  % The Swede keeps dogs
+  member([_, swede, _, dogs, _, _], G),
+  % The Dane drinks tea
+  member([_, dane, _, _, tea, _], G),
+  % The green house is just to the left of the white one
+  left([_, _, green, _, _, _], [_, _, white, _, _, _], G),
+  % The owner of the green house drinks coffee
+  member([_, _, green, _, coffee, _], G),
+  % The Pall Mall smoker keeps birds
+  member([_, _, _, birds, _, pallmall], G),
+  % The owner of the yellow house smokes Dunhills
+  member([_, _, yellow, _, _, dunhill], G),
+  % The man in the center house drinks milk
+  member([center, _, _, _, milk, _], G),
+  % The Norwegian lives in the first house
+  member([fleft, norwegian, _, _, _, _], G),
+  % The Blend smoker has a neighbor who keeps cats
+  next([_, _, _, _, _, blend], [_, _, _, cats, _, _], G),
+  % The man who smokes Blue Masters drinks bier
+  member([_, _, _, _, bier, bluemasters], G),
+  % The man who keeps horses lives next to the Dunhill smoker
+  next([_, _, _, _, _, dunhill], [_, _, _, horses, _, _], G),
+  % The German smokes Prince
+  member([_, german, _, _, _, prince], G),
+  % The Norwegian lives next to the blue house
+  next([_, norwegian, _, _, _, _], [_, _, blue, _, _, _], G),
+  % The Blend smoker has a neighbor who drinks water
+  next([_, _, _, _, _, blend], [_, _, _, _, water, _], G),
+
+  % 3. Implicit constraints:
+  % Pad with information about unmentioned atoms
+  member([left, _, _, _, _, _], G),
+  member([right, _, _, _, _, _], G),
+  member([fright, _, _, _, _, _], G),
+  member([_, _, _, fish, _, _], G).
+
+
+:- initialization main.
+main :-
+  puzzle(G),
+  format('Solution: ~w\n', [G]),
+  halt(0).


### PR DESCRIPTION
Here are two possible implementations to the Einstein puzzle, in Clojure and Prolog.

They have similar structure - Prolog uses it's native backtracking facilities, whereas in Clojure it's [core.logic](https://github.com/clojure/core.logic).

(this is done as part of the work suggested in #501)