### PR TITLE
Fix link to Cocktail Selection Sort in IMPLEMENTATIONS.md

### DIFF
--- a/IMPLEMENTATIONS.md
+++ b/IMPLEMENTATIONS.md
@@ -26,7 +26,7 @@
   * [python bucket sort](sort/python_bucket_sort)
   * [binary insertion sort](sort/binary%20insertion%20sort.cpp)
   * [slow sort](sort/Slow_Sort)
-  * [Cocktail Selection Sort](sort/Cocktail Selection Sort)
+  * [Cocktail Selection Sort](sort/Cocktail%20Selection%20Sort)
   * [Circle sort](sort/circle_sort)
   * [Gnome sort](sort/gnome_sort)
   * [Intro sort](sort/intro_sort)


### PR DESCRIPTION
The previous Markdown rendered poorly in Github's renderer, so the link didn't work. Changing the spaces to `%20`s fixed it.

**Fixes issue:** 
Markdown renderer stumbled over link with spaces, showed `[Cocktail Selection Sort](sort/Cocktail Selection Sort)` to the user instead of a hyperlinked `Cocktail Selection Sort`.

**Changes:**
Change spaces to `%20`s in the link address fixes the rendered hyperlink.
