### PR TITLE
Add huffman encoding for Go

### DIFF
--- a/greedy/huffman_coding/go/.gitignore
+++ b/greedy/huffman_coding/go/.gitignore
@@ -1,0 +1,2 @@
+# Ignore binary file
+huffman

--- a/greedy/huffman_coding/go/Makefile
+++ b/greedy/huffman_coding/go/Makefile
@@ -1,0 +1,2 @@
+all: 
+	go build -o huffman

--- a/greedy/huffman_coding/go/README.md
+++ b/greedy/huffman_coding/go/README.md
@@ -1,0 +1,27 @@
+# Overview
+
+This is an implementation of Huffman's encryption in go, generating a compression codebook from a byte array.
+
+## Build
+
+Simply call
+
+    make
+
+## Run
+
+Simply call
+
+    ./huffman <some text>
+
+The result will display the corresponding codebook.
+
+
+## Example
+
+    > huffman aaabccd
+    98 b [0 0 1]
+    100 d [0 0 0]
+    97 a [1]
+    99 c [0 1]
+

--- a/greedy/huffman_coding/go/huffman.go
+++ b/greedy/huffman_coding/go/huffman.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"sort"
+)
+
+// HuffmanTree is a codification of a Huffman tree. We arbitrary decide that we interpret the left tree as bit 1 and
+// the right tree as bit 0. In the right part of the tree we store the values for the level, i.e. the nearer to the
+// root on the right side, the higher the frequency of the respective character in the stream.
+type HuffmanTree struct {
+	Value byte
+	Left  *HuffmanTree
+	Right *HuffmanTree
+}
+
+func (tree HuffmanTree) String() string {
+	s1 := ""
+	s2 := ""
+	v := ""
+
+	if !tree.isLeaf() {
+		s1 = "right: " + tree.Right.String()
+		// We assume that we always have a left tree if we have a right tree.
+		s2 = ", left: " + tree.Left.String()
+	} else {
+		v = string(tree.Value)
+	}
+
+	return "{" + v + s1 + s2 + "}"
+}
+
+func (tree HuffmanTree) isLeaf() bool {
+	return tree.Right == nil && tree.Left == nil
+}
+
+// GetCodebook returns the codebook for this particular tree.
+func (tree HuffmanTree) GetCodebook() map[byte][]int {
+	m := make(map[byte][]int)
+
+	path := make([]int, 0)
+	for root := tree; root.Right != nil; root = *root.Left {
+		curPath := append(path, 1)
+		m[root.Right.Value] = curPath
+		path = append(path, 0)
+
+		// If we are at the last two elements, use 0 for the last element with the lowest frequency instead of 1.
+		if root.Left.Right == nil {
+			m[root.Left.Value] = path
+		}
+	}
+
+	return m
+}
+
+// GenerateHuffmanTree generates a HuffmanTree based on the data passed in the parameter.
+func NewHuffmanTree(s []byte) HuffmanTree {
+	frequencies := ComputeFrequency(s)
+	byteList := SortFrequencyList(frequencies)
+
+	// Combine single sorted lists to a single binary tree.
+	root := makeLeaf(byteList[0])
+	for _, leafValue := range byteList[1:] {
+		leaf := makeLeaf(leafValue)
+		root = combineLeafs(root, leaf)
+	}
+
+	return root
+}
+
+// makeLeaf generate a single leaf without children.
+func makeLeaf(value byte) HuffmanTree {
+	return HuffmanTree{Value: value}
+}
+
+// combineLeafs combines two trees into a single new one without a value. Note that we intentionally pass parameters
+// by value to have 'fresh' trees.
+func combineLeafs(left, right HuffmanTree) HuffmanTree {
+	return HuffmanTree{0, &left, &right}
+}
+
+// SortFrequencyList generates a list of bytes sorted by relative frequency, starting with the smallest ones.
+func SortFrequencyList(m map[byte]float32) []byte {
+	// Convert to array of struct values.
+	type kv struct {
+		Key   byte
+		Value float32
+	}
+	var kvs []kv
+	for k, v := range m {
+		kvs = append(kvs, kv{k, v})
+	}
+
+	// Sort array.
+	sort.Slice(kvs, func(i, j int) bool {
+		return kvs[i].Value < kvs[j].Value
+	})
+
+	// Convert to byte array.
+	var result []byte
+	for _, v := range kvs {
+		result = append(result, v.Key)
+	}
+	return result
+}
+
+// ComputeFrequency computes a relative frequency map of all characters in the array.
+func ComputeFrequency(s []byte) map[byte]float32 {
+	m := make(map[byte]float32)
+
+	// Count absolute number.
+	for _, v := range s {
+		m[v]++
+	}
+	// Compute relative number of occurrences.
+	for k, v := range m {
+		m[k] = v / float32(len(s))
+	}
+
+	return m
+}

--- a/greedy/huffman_coding/go/huffman_test.go
+++ b/greedy/huffman_coding/go/huffman_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestFrequencyEmpty(t *testing.T) {
+	m := ComputeFrequency([]byte(""))
+	if len(m) != 0 {
+		t.Error("len is not zero")
+	}
+}
+
+func TestFrequencySingle(t *testing.T) {
+	m := ComputeFrequency([]byte("a"))
+
+	if m[byte('a')] != 1.0 {
+		t.Error("Single frequency should be 1.0")
+	}
+}
+
+func TestFrequencyMultiple(t *testing.T) {
+	m := ComputeFrequency([]byte("aba"))
+
+	// If we generalize this, we should use epsilon-based comparison.
+	if m[byte('a')] != 0.6666667 {
+		t.Error("'a' frequency should be 0.66 but is", m[byte('a')])
+	}
+
+	if m[byte('b')] != 0.33333334 {
+		t.Error("'b' frequency should be 0.33 but is", m[byte('b')])
+	}
+}
+
+func TestSortedFrequencyMultiple(t *testing.T) {
+	m := ComputeFrequency([]byte("aba"))
+	s := SortFrequencyList(m)
+	expected := []byte{98, 97}
+	for k, v := range s {
+		if expected[k] != v {
+			t.Error("Byte ordering by frequency did not work")
+		}
+	}
+}
+
+func TestTreeGeneration(t *testing.T) {
+	tree := NewHuffmanTree([]byte("aaabbc"))
+
+	if tree.Right.Value != byte('a') {
+		t.Error("Expected a")
+	}
+	if tree.Left.Right.Value != byte('b') {
+		t.Error("Expected b")
+	}
+	if tree.Left.Left.Value != byte('c') {
+		t.Error("Expected c")
+	}
+}
+
+func TestCodebookGeneration(t *testing.T) {
+	tree := NewHuffmanTree([]byte("aababcabcd"))
+	codebook := tree.GetCodebook()
+
+	tests := [][]int{
+		{1}, codebook[byte('a')],
+		{0, 1}, codebook[byte('b')],
+		{0, 0, 1}, codebook[byte('c')],
+		{0, 0, 0}, codebook[byte('d')],
+	}
+
+	for k := 0; k < len(tests); k += 2 {
+		expected := tests[k]
+		result := tests[k+1]
+		if !reflect.DeepEqual(expected, result) {
+			t.Error("Expected other values!")
+			fmt.Println("Expected=", expected)
+			fmt.Println("Result=", result)
+		}
+	}
+}

--- a/greedy/huffman_coding/go/main.go
+++ b/greedy/huffman_coding/go/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	if len(os.Args) == 1 {
+		fmt.Println("Usage:", os.Args[0], "<text>")
+		return
+	}
+
+	data := strings.Join(os.Args[1:], " ")
+	tree := NewHuffmanTree([]byte(data))
+	codebook := tree.GetCodebook()
+	for k, v := range codebook {
+		display := ""
+		if k > 48 && k < 127 {
+			display = string(k)
+		}
+		fmt.Println(int(k), display, v)
+	}
+}


### PR DESCRIPTION
Add example of huffman encoding in Go

This example contains a short README.md, unit tests as well as a small command line utility.