### PR TITLE
Fix Python syntax error in triangles_printing

### DIFF
--- a/puzzles/triangles_printing/python.py
+++ b/puzzles/triangles_printing/python.py
@@ -1,4 +1,4 @@
-// range
+# range
 r = 9
 bound = round(r/2)
 


### PR DESCRIPTION
**Fixes issue:** #[Mention the issue number it fixes or add the details of the changes if it doesn't has a specific issue.]

**Changes:**
*/The issue is not specific. I can't fix that*/
